### PR TITLE
Add token auth ruby example

### DIFF
--- a/content/ruby/token_auth.md
+++ b/content/ruby/token_auth.md
@@ -1,0 +1,21 @@
+---
+title: "Password Auth"
+description: "Authenticate to the API with a username + password instead of an API key. Might be useful if you want to GET the api key without logging in to the portal"
+date: "2015-11-15"
+classes:
+    - "SoftLayer_Account"
+tags:
+    - "authentication"
+---
+
+```ruby
+require 'softlayer_api' # Requires softlayer_api >= 3.2
+
+# Create a client
+client = SoftLayer::Client.with_password(
+    username: 'change me', password: 'change me')
+
+# Test our client
+puts client['Account'].object_mask('mask[id, apiAuthenticationKeys]').
+    getCurrentUser
+```


### PR DESCRIPTION
Uses new addition in softlayer_ruby 3.2 to show how to authentication with a password (using token-based authentication.
