### PR TITLE
Add gem install information to server_locate.rb

### DIFF
--- a/content/ruby/server_locate.md
+++ b/content/ruby/server_locate.md
@@ -12,8 +12,8 @@ tags:
 
 
 ```ruby
-require 'softlayer_api'
-require 'table_print'
+require 'softlayer_api' # gem install softlayer_api
+require 'table_print' # gem install table_print
 
 # Credentials to the SoftLayer API are grabbed from the config file by default.
 # See https://github.com/softlayer/softlayer-ruby/blob/master/lib/softlayer/Config.rb#L11-L44


### PR DESCRIPTION
For the people really new to ruby and wondering what this "table_print" thing is, might be good to remind them its just a gem.
Probably good to do for all ruby scripts.

Or maybe we want to add that to the top of every script, "before running please install the following gems..."
