### PR TITLE
Removed one of the release note entries

### DIFF
--- a/content/release_notes/20160201.md
+++ b/content/release_notes/20160201.md
@@ -15,5 +15,4 @@ tags:
 
 #### Backend
 + Added the ability to specify userdata to [Hourly Bare Metal Servers](http://www.softlayer.com/info/hourly-bare-metal-servers)
-+ For dedicated firewalls, the private network bandwidth has been increased from 1.25 GB to unlimited. For shared firewalls, the private network bandwidth has been increased from 1.25GB to 10GB.
 + Enabled the automatic migration of local disk VSIs on disabled hosts on VSI power off or reboot.


### PR DESCRIPTION
After talking with Kyle, I removed one of the entries from last weeks Release notes. It is more of an internal issue and apparently caused some confusion with a customer. 
