### PR TITLE
Fixing sec group examples

### DIFF
--- a/content/python/createSecurityGroup.md
+++ b/content/python/createSecurityGroup.md
@@ -9,8 +9,6 @@ tags:
 
 ---
 
-The Security Group offering is currently in Beta. The use of this feature is restricted to select users. When the Beta period is over, security groups will be available for all users. Contact sgbeta@us.ibm.com using 'Security Groups' in the subject line with any questions.
-
 ## Creating a Security Group
 
 ```python

--- a/content/ruby/addRemoveSecurityGroupRules.md
+++ b/content/ruby/addRemoveSecurityGroupRules.md
@@ -8,8 +8,6 @@ tags:
     - "objectTemplate"
 ---
 
-The Security Group offering is currently in Beta. The use of this feature is restricted to select users. When the Beta period is over, security groups will be available for all users. Contact sgbeta@us.ibm.com using ‘Security Groups’ in the subject line with any questions.
-
 ### Adding Rules
 
 ```ruby

--- a/content/ruby/createSecurityGroup.md
+++ b/content/ruby/createSecurityGroup.md
@@ -8,8 +8,6 @@ tags:
     - "objectTemplate"
 ---
 
-The Security Group offering is currently in Beta. The use of this feature is restricted to select users. When the Beta period is over, security groups will be available for all users. Contact sgbeta@us.ibm.com using ‘Security Groups’ in the subject line with any questions.
-
 ```ruby 
 
 =begin

--- a/content/ruby/getSecurityGroupDetails.md
+++ b/content/ruby/getSecurityGroupDetails.md
@@ -8,8 +8,6 @@ tags:
     - "getAllObjects"
 ---
 
-The Security Group offering is currently in Beta. The use of this feature is restricted to select users. When the Beta period is over, security groups will be available for all users. Contact sgbeta@us.ibm.com using ‘Security Groups’ in the subject line with any questions.
-
 ```ruby
 
 =begin


### PR DESCRIPTION
Removed Beta wording from the Security group examples. 