### PR TITLE
Add return values to security group REST examples

### DIFF
--- a/content/rest/addGetEditRemoveSecurityGroupRules.md
+++ b/content/rest/addGetEditRemoveSecurityGroupRules.md
@@ -18,9 +18,27 @@ URL: `SoftLayer_Network_SecurityGroup/{securitygroup_id}/addRules`
 
 Example CURL:
 ```
-$ curl --user "$SOFTLAYER_USERNAME:$SOFTLAYER_API_KEY" -X POST 'https://api.softlayer.com/rest/v3/SoftLayer_Network_SecurityGroup/136741/addRules' -d '{"parameters": [[{"direction": "ingress","portRangeMin":100,"portRangeMax":101,"protocol":"tcp"}]]}'
+$ curl --user "$SOFTLAYER_USERNAME:$SOFTLAYER_API_KEY" -X POST 'https://api.softlayer.com/rest/v3/SoftLayer_Network_SecurityGroup/461903/addRules' -d '{"parameters": [[{"direction": "ingress","portRangeMin":100,"portRangeMax":101,"protocol":"tcp"}]]}'
 ```
 
+Example Response:
+```
+{
+    "requestId": "c0796ae700a8fad97170168",
+    "rules": [
+        {
+            "direction": "ingress",
+            "ethertype": "IPv4",
+            "id": 789953,
+            "portRangeMax": 101,
+            "portRangeMin": 100,
+            "protocol": "tcp",
+            "remoteGroupId": null,
+            "securityGroupId": 461903
+        }
+    ]
+}
+```
 ---
 
 ### Get rules
@@ -58,6 +76,7 @@ Example Response:
 
 ```
 ---
+
 ### Edit Rules
 
 Operation: `PUT`
@@ -66,9 +85,37 @@ URL: `SoftLayer_Network_SecurityGroup/{securitygroup_id}/editRules`
 
 Example CURL:
 ```
-$ curl --user "$SOFTLAYER_USERNAME:$SOFTLAYER_API_KEY" -X PUT 'https://api.softlayer.com/rest/v3/SoftLayer_Network_SecurityGroup/123456/editRules' -d '{"parameters": [[{"id": 11111,"portRangeMin": 99},{"id": 22222,"portRangeMin": 199}]]}'
+$ curl --user "$SOFTLAYER_USERNAME:$SOFTLAYER_API_KEY" -X PUT 'https://api.softlayer.com/rest/v3/SoftLayer_Network_SecurityGroup/461903/editRules' -d '{"parameters": [[{"id": 789953,"portRangeMax": 110},{"id": 790219,"portRangeMax": 199}]]}'
 ```
 
+Example Response:
+```
+{
+    "requestId": "fd56048502cc26e659aacff",
+    "rules": [
+        {
+            "direction": "ingress",
+            "ethertype": "IPv4",
+            "id": 789953,
+            "portRangeMax": 110,
+            "portRangeMin": 100,
+            "protocol": "tcp",
+            "remoteGroupId": null,
+            "securityGroupId": 461903
+        },
+        {
+            "direction": "ingress",
+            "ethertype": "IPv4",
+            "id": 790219,
+            "portRangeMax": 199,
+            "portRangeMin": 100,
+            "protocol": "tcp",
+            "remoteGroupId": null,
+            "securityGroupId": 461903
+        }
+    ]
+}
+```
 ---
 
 ### Remove Rules
@@ -79,6 +126,24 @@ URL: `SoftLayer_Network_SecurityGroup/{securitygroup_id}/removeRules`
 
 Example CURL:
 ```
-$ curl --user "$SOFTLAYER_USERNAME:$SOFTLAYER_API_KEY" -X PUT 'https://api.softlayer.com/rest/v3/SoftLayer_Network_SecurityGroup/123456/removeRules' -d '{"parameters": [[11111]]}'
+$ curl --user "$SOFTLAYER_USERNAME:$SOFTLAYER_API_KEY" -X PUT 'https://api.softlayer.com/rest/v3/SoftLayer_Network_SecurityGroup/461903/removeRules' -d '{"parameters": [[789953]]}'
 ```
 
+Example Response:
+```
+{
+    "requestId": "66cb42be41a2d6a1f82a24b",
+    "rules": [
+        {
+            "direction": "ingress",
+            "ethertype": "IPv4",
+            "id": 789953,
+            "portRangeMax": 110,
+            "portRangeMin": 100,
+            "protocol": "tcp",
+            "remoteGroupId": null,
+            "securityGroupId": 461903
+        }
+    ]
+}
+```

--- a/content/rest/getAttachDetachNetworkComponent.md
+++ b/content/rest/getAttachDetachNetworkComponent.md
@@ -17,7 +17,7 @@ URL: `SoftLayer_Virtual_Guest/{guest_id}/getObject.json?objectMask=mask[networkC
 
 Example CURL:
 ```
-$ curl --user "$SOFTLAYER_USERNAME:$SOFTLAYER_API_KEY" -g -X GET 'https://api.softlayer.com/rest/v3/SoftLayer_Virtual_Guest/30000007/getObject.json?objectMask=mask[networkComponents.port,networkComponents.id]'
+$ curl --user "$SOFTLAYER_USERNAME:$SOFTLAYER_API_KEY" -g -X GET 'https://api.softlayer.com/rest/v3/SoftLayer_Virtual_Guest/39269481/getObject.json?objectMask=mask[networkComponents.port,networkComponents.id]'
 ```
 Example Response:
 ```
@@ -25,11 +25,11 @@ Example Response:
     <output omitted>
     "networkComponents": [
         {
-            "id": 20000003,
+            "id": 21781733,
             "port": 0
         },
         {
-            "id": 20000001,
+            "id": 21781731,
             "port": 1
         }
     ],
@@ -46,7 +46,14 @@ URL: `SoftLayer_Network_SecurityGroup/{securitygroup_id}/attachNetworkComponents
 
 Example CURL:
 ```
-$ curl --user "$SOFTLAYER_USERNAME:$SOFTLAYER_API_KEY" -X POST 'https://api.softlayer.com/rest/v3/SoftLayer_Network_SecurityGroup/123456/attachNetworkComponents' -d '{"parameters": [[20000003]]}'
+$ curl --user "$SOFTLAYER_USERNAME:$SOFTLAYER_API_KEY" -X POST 'https://api.softlayer.com/rest/v3/SoftLayer_Network_SecurityGroup/461903/attachNetworkComponents' -d '{"parameters": [[21781731]]}'
+```
+
+Example Response:
+```
+{
+    "requestId": "3d1bf39a0a0e4d699335c12"
+}
 ```
 ---
 
@@ -58,5 +65,12 @@ URL: `SoftLayer_Network_SecurityGroup/{securitygroup_id}/detachNetworkComponents
 
 Example CURL:
 ```
-$ curl --user "$SOFTLAYER_USERNAME:$SOFTLAYER_API_KEY" -X POST 'https://api.softlayer.com/rest/v3/SoftLayer_Network_SecurityGroup/123456/detachNetworkComponents' -d '{"parameters": [[20000003]]}'
+$ curl --user "$SOFTLAYER_USERNAME:$SOFTLAYER_API_KEY" -X POST 'https://api.softlayer.com/rest/v3/SoftLayer_Network_SecurityGroup/461903/detachNetworkComponents' -d '{"parameters": [[21781731]]}'
+```
+
+Example Response:
+```
+{
+    "requestId": "12b9e0b9459a1e000bfb169"
+}
 ```


### PR DESCRIPTION
Update the security group REST examples to show the return values for each API call.