### PR TITLE
Fix infinite loop in goland event logs example.

### DIFF
--- a/content/go/event_log.go.md
+++ b/content/go/event_log.go.md
@@ -152,8 +152,12 @@ func getAllEvents(
 	var allEvents []datatypes.Event_Log
 	for eventsSize<=maxNumberOfEvents {
 		events := getAllObjects(limit,offset,filter,mask)
+		// return if the events are a list of empty structure like [{}]
+		if events[0]==(datatypes.Event_Log{}){
+			return allEvents
+		}
 		allEvents=append(allEvents, events...)
-		eventsSize=len(allEvents)+pagination
+		eventsSize=eventsSize+pagination
 	}
 	return allEvents
 }


### PR DESCRIPTION
#470 fix infinite loop in Goland event logs example when `Event_Log::getAllObjects` retrieve a list of an empty log like `[{}]`