### PR TITLE
 removed the Git version info

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,14 +13,10 @@ pygmentsCodefencesGuessSyntax = true
 
 refLinksErrorLevel = "WARNING"
 refLinksNotFoundURL = '#'
-enableGitInfo = true
 
 [params]
   description = "SoftLayer API Examples, implementations, and release notes."
   author = "SoftLayer"
-
-[frontmatter]
-  lastmod = [":git", "date"]
 
 [taxonomies]
 	tag = "tags"

--- a/layouts/reference/datatype.html
+++ b/layouts/reference/datatype.html
@@ -19,6 +19,5 @@
     <hr>
 
 {{ partial "footer.copyright.html" . }}
-{{ .Title }} was last updated on {{ .Lastmod.Format "January 2, 2006" }}: {{ .GitInfo.Subject }} ({{ .GitInfo.AbbreviatedHash }})
 </div>
 {{ partial "footer.html" . }}

--- a/layouts/reference/method.html
+++ b/layouts/reference/method.html
@@ -21,7 +21,6 @@
     <hr>
 
 {{ partial "footer.copyright.html" . }}
-{{ .Title }} was last updated on {{ .Lastmod.Format "January 2, 2006" }}: {{ .GitInfo.Subject }} ({{ .GitInfo.AbbreviatedHash }})
 </div>
 {{ partial "footer.html" . }}
 

--- a/layouts/reference/service.html
+++ b/layouts/reference/service.html
@@ -22,7 +22,6 @@
 
 
 {{ partial "footer.copyright.html" . }}
-{{ .Title }} was last updated on {{ .Lastmod.Format "January 2, 2006" }}: {{ .GitInfo.Subject }} ({{ .GitInfo.AbbreviatedHash }})
 </div>
 
 {{ partial "footer.html" . }}


### PR DESCRIPTION
removed the Git version info because the devapp servers have a superold version of git that doesn't support this function sadly.