### PR TITLE
Fixed service method page to say 'Description'

### DIFF
--- a/layouts/reference/method.html
+++ b/layouts/reference/method.html
@@ -30,7 +30,7 @@ REMOVE_THIS_PAGE
             <p>
                 {{ $thisPage.docOverview | markdownify }}
             </p>
-            <h2>Overview</h2>
+            <h2>Description</h2>
 
                 {{ $thisPage.doc | markdownify }}
 


### PR DESCRIPTION
Fixes #549 
Fixed service method page to say 'Description', like all other pages, instead of 'overview' which can be confusing