### PR TITLE
Retrieve 'priceId' instead of 'id' from serversToReload to reloadOperatingSystem

### DIFF
--- a/content/python/reload_hardware.md
+++ b/content/python/reload_hardware.md
@@ -152,7 +152,7 @@ try:
         config = {
             'itemPrices': [
                 {
-                    'id': serversToReload[ipToReload]['id']
+                    'id': serversToReload[ipToReload]['priceId']
                 }
                 ]
             }


### PR DESCRIPTION
We need to send the PriceId instead of Id from serversToReload to hardwareService.reloadOperatingSystem